### PR TITLE
Move callbacks above main

### DIFF
--- a/orionteste25.py
+++ b/orionteste25.py
@@ -3063,14 +3063,6 @@ def persist_state(search, cluster, driving_forces, chips, logic, n_save, project
     save_projects(projects)
     return f"Saved: {datetime.now().strftime('%H:%M:%S')}"
 
-if __name__ == "__main__":
-    print(">>> Starting ORION app...")
-    with server.app_context():
-        print(">>> [DEBUG] Before db.create_all()")
-        db.create_all()
-        print(">>> [DEBUG] After db.create_all()")
-    port = int(os.environ.get("PORT", 8050))
-    app.run(host="0.0.0.0", port=port, debug=False)
 # --- Project Management Callbacks ---
 # (Check for presence at file bottom)
 
@@ -3520,3 +3512,12 @@ def unified_chip_logic_filter_callback(
 
     # Default (shouldn't happen)
     raise PreventUpdate
+if __name__ == "__main__":
+    print(">>> Starting ORION app...")
+    with server.app_context():
+        print(">>> [DEBUG] Before db.create_all()")
+        db.create_all()
+        print(">>> [DEBUG] After db.create_all()")
+    port = int(os.environ.get("PORT", 8050))
+    app.run(host="0.0.0.0", port=port, debug=False)
+


### PR DESCRIPTION
## Summary
- ensure callback definitions come before app startup
- run app after callbacks register

## Testing
- `python -m py_compile orionteste25.py`

------
https://chatgpt.com/codex/tasks/task_e_6842d27b9bc08331ba8c367d25ba339b