### PR TITLE
Fix logger initialization

### DIFF
--- a/orionteste25.py
+++ b/orionteste25.py
@@ -8,6 +8,10 @@ import pickle
 import io
 import sys
 import logging
+
+# Initialize logging before first use
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 import re
 import json
 from datetime import datetime
@@ -130,8 +134,6 @@ openai.api_key = api_key
 client = OpenAI(api_key=api_key)
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
 
 # --- DASH APP INIT ---
 app = dash.Dash(


### PR DESCRIPTION
## Summary
- initialize logger before first usage

## Testing
- `python -m py_compile orionteste25.py`
- `python -m py_compile preprocessteste.py`


------
https://chatgpt.com/codex/tasks/task_e_684349d1da248331966ff9d49d06dd03