### PR TITLE
Remove leftover debug logs

### DIFF
--- a/orionteste25.py
+++ b/orionteste25.py
@@ -42,7 +42,7 @@ from nltk.corpus import stopwords
 
 from dash import ctx
 
-logger.debug("After imports")
+# logger.debug("After imports")
 
 
 # --- PROJECTS/DASHBOARD STATE PERSISTENCE LOGIC ---
@@ -3531,11 +3531,11 @@ def unified_chip_logic_filter_callback(
     # Default (shouldn't happen)
     raise PreventUpdate
 if __name__ == "__main__":
-    logger.debug("Starting ORION app...")
+    # logger.debug("Starting ORION app...")
     with server.app_context():
-        logger.debug("Before db.create_all()")
+        # logger.debug("Before db.create_all()")
         db.create_all()
-        logger.debug("After db.create_all()")
+        # logger.debug("After db.create_all()")
     port = int(os.environ.get("PORT", 8050))
     app.run(host="0.0.0.0", port=port, debug=False)
 


### PR DESCRIPTION
## Summary
- cleanup debug logger output in `orionteste25.py`

## Testing
- `python -m py_compile orionteste25.py`


------
https://chatgpt.com/codex/tasks/task_e_68434f704a10833188c08bc4525485f7