### PR TITLE
Add page routing for modular ORION package

### DIFF
--- a/orion/__init__.py
+++ b/orion/__init__.py
@@ -16,4 +16,10 @@ login_manager.init_app(server)
 app = dash.Dash(__name__, server=server, external_stylesheets=[dbc.themes.BOOTSTRAP])
 app.config.suppress_callback_exceptions = True
 
+# Import page definitions after the app instance is created so callbacks
+# register correctly. The ``pages`` module provides the top-level layout and
+# routing callbacks used by the minimal ORION dashboard.
+from . import pages
+app.layout = pages.layout()
+
 __all__ = ['app', 'server', 'db', 'login_manager']

--- a/orion/callbacks/__init__.py
+++ b/orion/callbacks/__init__.py
@@ -1,1 +1,8 @@
-from . import info
+"""Aggregate application callbacks."""
+
+# Import modules that define callbacks so that Dash registers them when this
+# package is imported by ``run.py``.
+from .. import auth   # noqa: F401
+from .. import pages  # noqa: F401
+from . import info     # noqa: F401
+

--- a/orion/pages/__init__.py
+++ b/orion/pages/__init__.py
@@ -1,0 +1,25 @@
+"""Page layout and routing callbacks for the ORION dashboard."""
+
+from dash import html, dcc, callback, Output, Input
+
+from .. import app
+from ..layouts import login, register, main
+
+
+def layout():
+    """Return the top-level application layout."""
+    return html.Div([
+        dcc.Location(id="url", refresh=False),
+        html.Div(id="page-content")
+    ])
+
+
+@callback(Output("page-content", "children"), Input("url", "pathname"))
+def render_page(pathname: str):
+    """Render the appropriate page for ``pathname``."""
+    if pathname == "/login":
+        return login.layout()
+    if pathname == "/register":
+        return register.layout()
+    # Default route
+    return main.layout()


### PR DESCRIPTION
## Summary
- wire up page routing inside the `orion` package
- provide a pages module with simple navigation layout
- register callbacks when importing `orion.callbacks`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843556bc6848331922a511c64b760d6