### PR TITLE
Fix node selection persistence

### DIFF
--- a/orionteste25.py
+++ b/orionteste25.py
@@ -3468,6 +3468,8 @@ def handle_node_selection(selected, current_project):
         selected_ids = []
     else:
         selected_ids = [pt.get("customdata", [None])[0] for pt in selected.get("points", [])]
+    if current_project not in projects:
+        projects[current_project] = default_project_state()
     projects[current_project]["selected_nodes"] = selected_ids
     save_projects(projects)
     return selected_ids


### PR DESCRIPTION
## Summary
- ensure project exists in `handle_node_selection` before updating project state

## Testing
- `python -m py_compile orionteste25.py`


------
https://chatgpt.com/codex/tasks/task_e_6843ddf3a8848331bbb8b6adcd3f7b24